### PR TITLE
AppSettings for Toolbox.WebComponentsBaseFolder added

### DIFF
--- a/Dit.Umb.ToolBox/Web.config
+++ b/Dit.Umb.ToolBox/Web.config
@@ -39,6 +39,7 @@
     <add key="owin:appStartup" value="UmbracoDefaultOwinStartup" />
     <add key="Umbraco.ModelsBuilder.Enable" value="true" />
     <add key="Umbraco.ModelsBuilder.ModelsMode" value="PureLive" />
+    <add key="Toolbox.WebComponentsBaseFolder" value="/web-components-cms-template" />
   </appSettings>
   <connectionStrings configSource="config\connectionStrings.config" />
   <system.data>


### PR DESCRIPTION
Missing AppSetting for installation with the default WebComponents